### PR TITLE
delete tab permission

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -8,7 +8,7 @@ export default defineManifest({
   omnibox: {
     keyword: "b",
   },
-  permissions: ["bookmarks", "tabs"],
+  permissions: ["bookmarks"],
   background: { service_worker: "src/background/index.ts" },
   action: {
     default_popup: "index.html",


### PR DESCRIPTION
chrome.tabs.createとかなら、permissionは不要らしい。

↓[chrome.tabs - Chrome Developers](https://developer.chrome.com/docs/extensions/reference/tabs/#perms)より引用

> Most features do not require any permissions to use. For example: [creating](https://developer.chrome.com/docs/extensions/reference/tabs/#method-create) a new tab, [reloading](https://developer.chrome.com/docs/extensions/reference/tabs/#method-reload) a tab, [navigating](https://developer.chrome.com/docs/extensions/reference/tabs/#method-update) to another URL, etc.